### PR TITLE
XML workaround for patch endpoint json bug

### DIFF
--- a/lib/jamf_helper.php
+++ b/lib/jamf_helper.php
@@ -372,12 +372,7 @@ class Jamf_helper
               $Jamf_model->patch_reporting_software_titles_management = "[]";
             }
 
-            // Process patches section separately as XML because of limitations (bug?) with JSON format
-            // Get computer data from Jamf
-            $url = "{$jamf_server}/JSSResource/computermanagement/serialnumber/{$Jamf_model->serial_number}";
-            $jamf_patch_policy_xml_result = $this->get_jamf_url_xml($url);
-
-            $xml = simplexml_load_string($jamf_patch_policy_xml_result);
+                        $xml = simplexml_load_string($jamf_patch_policy_xml_result);
             if (isset($jxml->patch_reporting)) {
               $patch_policy_array = []; // Create patch policy array
               foreach ($xml->patch_reporting->patch_policies->patch_policy as $patch_policies) {

--- a/lib/jamf_helper.php
+++ b/lib/jamf_helper.php
@@ -372,8 +372,6 @@ class Jamf_helper
               $Jamf_model->patch_reporting_software_titles_management = "[]";
             }
 
-                        $xml = simplexml_load_string($jamf_patch_policy_xml_result);
-            if (isset($jxml->patch_reporting)) {
               $patch_policy_array = []; // Create patch policy array
               foreach ($xml->patch_reporting->patch_policies->patch_policy as $patch_policies) {
                 $patch_policy = []; // Create patch titles array


### PR DESCRIPTION
Patch related endpoints have broken JSON. Something to do with how XML is turned into JSON on the server. Instead of an array it becomes a hash/dict with one key holding the last value only, all others are missing.

XML response is complete. 

Change utilizes unused xml logic earlier in code to address the same issue device storage values.